### PR TITLE
feat: bump version to latest release +1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -152,6 +152,8 @@ cython_debug/
 
 .vscode/
 
+# pyenv
+.python-version
 
 # OWN
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "portfolyo"
-version = "0.5.4"
+version = "0.5.7"
 description = "Analyse and manipulate timeseries related to power and gas offtake portfolios"
 authors = [
     "Ruud Wijtvliet <rwijtvliet@gmail.com>",


### PR DESCRIPTION
It seems that the release pipeline failed because while new tags were created, you forgot to bump the poetry version. The way CI is currently set up in your repo, you will have to do that by hand still (`poetry version major|minor|patch`)

<!-- readthedocs-preview portfolyo start -->
----
:books: Documentation preview :books:: https://portfolyo--69.org.readthedocs.build/en/69/

<!-- readthedocs-preview portfolyo end -->