### PR TITLE
Startenderror

### DIFF
--- a/portfolyo/core/pfline/classes.py
+++ b/portfolyo/core/pfline/classes.py
@@ -96,6 +96,16 @@ class PfLine(
         return self.df.index
 
     @property
+    def start(self) -> pd.Timestamp:
+        """Start (incl) of the portfolio line."""
+        return self.df.index[0]
+
+    @property
+    def end(self) -> pd.Timestamp:
+        """End (excl) of the portfolio line."""
+        return tools.right.index(self.df.index)[-1]
+
+    @property
     @abc.abstractmethod
     def w(self) -> pd.Series:
         """Return (flat) volume timeseries in [MW]."""

--- a/portfolyo/tools/right.py
+++ b/portfolyo/tools/right.py
@@ -7,7 +7,7 @@ import pandas as pd
 from . import freq as tools_freq
 
 
-def stamp(ts: pd.Timestamp, freq: str = None) -> pd.Timestamp:
+def stamp(ts: pd.Timestamp, freq: str) -> pd.Timestamp:
     f"""Right-bound timestamp belonging to left-bound timestamp.
 
     Parameters

--- a/tests/core/pfline/test_pfline_init.py
+++ b/tests/core/pfline/test_pfline_init.py
@@ -272,8 +272,8 @@ def test_init_with_integers(col: str):
 @pytest.mark.parametrize("freq", ["15min", "h"])
 def test_contain_whole_day(inclusive: str, freq: str):
     """An index must contain full days.
-    For hourly-or-shorter values, this means that the start time of the first period () must equal the end time of the
-    last period (), which is not the case."""
+    For hourly-or-shorter values, this means that the start time of the first period must equal the end time of the last period.
+    """
     index = pd.date_range(
         "2020-01-01", "2020-02-01", freq=freq, tz="Europe/Berlin", inclusive=inclusive
     )
@@ -281,6 +281,9 @@ def test_contain_whole_day(inclusive: str, freq: str):
         # This should work without any error
         pfl = dev.get_flatpfline(index)
         assert isinstance(pfl, PfLine)
+        pf.testing.assert_index_equal(pfl.index, index)
+        assert pfl.start == index[0]
+        assert pfl.end not in index  # because exclusive
     else:
         # For "both" inclusive, it should raise an error
         with pytest.raises(ValueError):


### PR DESCRIPTION
added start and end to portfolio line properties

<!-- readthedocs-preview portfolyo start -->
----
📚 Documentation preview 📚: https://portfolyo--114.org.readthedocs.build/en/114/

<!-- readthedocs-preview portfolyo end -->