### PR TITLE
changes to toml file to include it in a wheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ authors = [
 ]
 license = "BSD-3"
 readme = "README.rst"
+include = ["pyproject.toml"]
 
 [tool.poetry.dependencies]
 python = "^3.10"
@@ -87,3 +88,5 @@ checks = [
     "SA01",
     "ES01",
 ]
+
+


### PR DESCRIPTION
pyproject.toml should be included in a wheel to be accessible as site-package

<!-- readthedocs-preview portfolyo start -->
----
📚 Documentation preview 📚: https://portfolyo--132.org.readthedocs.build/en/132/

<!-- readthedocs-preview portfolyo end -->